### PR TITLE
use f-strings for baseline_dates

### DIFF
--- a/analysis/study_definition_controlactual.py
+++ b/analysis/study_definition_controlactual.py
@@ -50,11 +50,11 @@ treatment = study_params[cohort]["treatment"]
 ############################################################
 ## inclusion variables
 from variables_inclusion import generate_inclusion_variables 
-inclusion_variables = generate_inclusion_variables(index_date="trial_date")
+inclusion_variables = generate_inclusion_variables(baseline_date="trial_date")
 ############################################################
 ## matching variables
 from variables_matching import generate_matching_variables 
-matching_variables = generate_matching_variables(index_date="trial_date")
+matching_variables = generate_matching_variables(baseline_date="trial_date")
 ############################################################
 
 
@@ -98,7 +98,6 @@ study = StudyDefinition(
       AND 
       (covid_vax_any_{vaxn-1}_date = covid_vax_{treatment}_{vaxn-1}_date)
     """,
-    #NOT (covid_vax_any_1_date <= index_date) # doesn't work for some reason `unknown colunm : index_date`
     #previouslymatched = patients.which_exist_in_file(f_path="output/match/cumulative_matchedcontrols{matching_round}.csv.gz"),
   start_date_0 = patients.fixed_value(start_date_0),
   end_date_0 = patients.fixed_value(end_date_0),  
@@ -117,7 +116,7 @@ study = StudyDefinition(
   
   **vaccination_date_X(
     name = "covid_vax_any",
-    index_date = "1900-01-01",
+    on_or_after = "1900-01-01",
     n = 3,
     delay=1,
     target_disease_matches="SARS-2 CORONAVIRUS"
@@ -127,7 +126,7 @@ study = StudyDefinition(
     name = "covid_vax_pfizerA",
     # use 1900 to capture all possible recorded covid vaccinations, including date errors
     # any vaccines occurring before national rollout are later excluded
-    index_date = "1900-01-01", 
+    on_or_after = "1900-01-01", 
     n = 2,
     delay=1,
     product_name_matches="COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc for susp for inj MDV (Pfizer)"
@@ -136,7 +135,7 @@ study = StudyDefinition(
   # pfizer approved for use in children (5-11)
   **vaccination_date_X(
     name = "covid_vax_pfizerC",
-    index_date = "1900-01-01",
+    on_or_after = "1900-01-01",
     n = 2,
     delay=1,
     product_name_matches="COVID-19 mRNA Vaccine Comirnaty Children 5-11yrs 10mcg/0.2ml dose conc for disp for inj MDV (Pfizer)"

--- a/analysis/study_definition_controlfinal.py
+++ b/analysis/study_definition_controlfinal.py
@@ -50,7 +50,7 @@ treatment = study_params[cohort]["treatment"]
 ############################################################
 ## outcome variables
 from variables_outcome import generate_outcome_variables 
-outcome_variables = generate_outcome_variables(index_date="trial_date")
+outcome_variables = generate_outcome_variables(baseline_date="trial_date")
 ############################################################
 
 

--- a/analysis/study_definition_controlpotential.py
+++ b/analysis/study_definition_controlpotential.py
@@ -53,11 +53,11 @@ treatment = study_params[cohort]["treatment"]
 ############################################################
 ## inclusion variables
 from variables_inclusion import generate_inclusion_variables 
-inclusion_variables = generate_inclusion_variables(index_date="index_date")
+inclusion_variables = generate_inclusion_variables(baseline_date="index_date")
 ############################################################
 ## matching variables
 from variables_matching import generate_matching_variables 
-matching_variables = generate_matching_variables(index_date="index_date")
+matching_variables = generate_matching_variables(baseline_date="index_date")
 ############################################################
 
 
@@ -94,8 +94,7 @@ study = StudyDefinition(
       AND 
       (covid_vax_any_{vaxn-1}_date = covid_vax_{treatment}_{vaxn-1}_date)
     """,
-    #NOT (covid_vax_any_1_date <= index_date) # doesn't work for some reason `unknown colunm : index_date`
-    # NOTE: all all ..._0_date variables are set to be equal so that for vaxn=1 the vaxn-1 logic is true 
+    # NOTE: all ..._0_date variables are set to be equal so that for vaxn=1 the vaxn-1 logic is true 
     #previouslymatched = patients.which_exist_in_file(f_path="output/match/cumulative_matchedcontrols{matching_round}.csv.gz"),
     start_date_0 = patients.fixed_value(start_date_0),
     end_date_0 = patients.fixed_value(end_date_0),  
@@ -110,7 +109,7 @@ study = StudyDefinition(
   
   **vaccination_date_X(
     name = "covid_vax_any",
-    index_date = "1900-01-01",
+    on_or_after = "1900-01-01",
     n = 3,
     delay=1,
     target_disease_matches="SARS-2 CORONAVIRUS"
@@ -120,7 +119,7 @@ study = StudyDefinition(
     name = "covid_vax_pfizerA",
     # use 1900 to capture all possible recorded covid vaccinations, including date errors
     # any vaccines occurring before national rollout are later excluded
-    index_date = "1900-01-01", 
+    on_or_after = "1900-01-01", 
     n = 3,
     delay=1,
     product_name_matches="COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc for susp for inj MDV (Pfizer)"
@@ -129,7 +128,7 @@ study = StudyDefinition(
   # pfizer approved for use in children (5-11)
   **vaccination_date_X(
     name = "covid_vax_pfizerC",
-    index_date = "1900-01-01",
+    on_or_after = "1900-01-01",
     n = 3,
     delay=1,
     product_name_matches="COVID-19 mRNA Vaccine Comirnaty Children 5-11yrs 10mcg/0.2ml dose conc for disp for inj MDV (Pfizer)"

--- a/analysis/study_definition_treated.py
+++ b/analysis/study_definition_treated.py
@@ -48,15 +48,15 @@ treatment = study_params[cohort]["treatment"]
 ############################################################
 ## inclusion variables
 from variables_inclusion import generate_inclusion_variables 
-inclusion_variables = generate_inclusion_variables(index_date=f"covid_vax_any_{vaxn}_date")
+inclusion_variables = generate_inclusion_variables(baseline_date=f"covid_vax_any_{vaxn}_date")
 ############################################################
 ## matching variables
 from variables_matching import generate_matching_variables 
-matching_variables = generate_matching_variables(index_date=f"covid_vax_any_{vaxn}_date")
+matching_variables = generate_matching_variables(baseline_date=f"covid_vax_any_{vaxn}_date")
 ############################################################
 ## outcome variables
 from variables_outcome import generate_outcome_variables 
-outcome_variables = generate_outcome_variables(index_date=f"covid_vax_any_{vaxn}_date")
+outcome_variables = generate_outcome_variables(baseline_date=f"covid_vax_any_{vaxn}_date")
 ############################################################
 
 
@@ -112,7 +112,7 @@ study = StudyDefinition(
   
   **vaccination_date_X(
     name = "covid_vax_any",
-    index_date = "1900-01-01",
+    on_or_after = "1900-01-01",
     n = 3,
     delay = 1,
     target_disease_matches="SARS-2 CORONAVIRUS"
@@ -123,7 +123,7 @@ study = StudyDefinition(
     name = "covid_vax_pfizerA",
     # use 1900 to capture all possible recorded covid vaccinations, including date errors
     # any vaccines occurring before national rollout are later excluded
-    index_date = "1900-01-01", 
+    on_or_after = "1900-01-01", 
     n = 3,
     delay = 1,
     product_name_matches="COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc for susp for inj MDV (Pfizer)"
@@ -132,7 +132,7 @@ study = StudyDefinition(
   # pfizer approved for use in children (5-11)
   **vaccination_date_X(
     name = "covid_vax_pfizerC",
-    index_date = "1900-01-01",
+    on_or_after = "1900-01-01",
     n = 3,
     delay = 1,
     product_name_matches="COVID-19 mRNA Vaccine Comirnaty Children 5-11yrs 10mcg/0.2ml dose conc for disp for inj MDV (Pfizer)"

--- a/analysis/variables_demo.py
+++ b/analysis/variables_demo.py
@@ -2,16 +2,16 @@ from cohortextractor import patients
 from codelists import *
 import codelists
 
-def generate_demo_variables(index_date):
+def generate_demo_variables(baseline_date):
   demo_variables = dict(
 
     has_follow_up_previous_6weeks=patients.registered_with_one_practice_between(
-      start_date="index_date - 42 days",
-      end_date="index_date",
+      start_date=f"{baseline_date} - 42 days",
+      end_date=baseline_date,
     ),
     
     age=patients.age_as_of( 
-      "index_date - 1 day",
+      f"{baseline_date} - 1 day",
     ),
     
     ageband=patients.categorised_as(
@@ -49,7 +49,7 @@ def generate_demo_variables(index_date):
         # set maximum to avoid any impossibly extreme values being classified as obese
       },
       bmi_value=patients.most_recent_bmi(
-        on_or_after="index_date - 5 years",
+        on_or_after=f"{baseline_date} - 5 years",
         minimum_age_at_measurement=16
       ),
       return_expectations={
@@ -72,7 +72,7 @@ def generate_demo_variables(index_date):
     # practice pseudo id
   
     # practice_id=patients.registered_practice_as_of(
-    #   "index_date - 1 day",
+    #   f"{baseline_date} - 1 day",
     #   returning="pseudo_id",
     #   return_expectations={
     #     "int": {"distribution": "normal", "mean": 1000, "stddev": 100},
@@ -83,7 +83,7 @@ def generate_demo_variables(index_date):
     # msoa
     
     msoa=patients.address_as_of(
-      "index_date - 1 day",
+      f"{baseline_date} - 1 day",
       returning="msoa",
       return_expectations={
         "rate": "universal",
@@ -96,7 +96,7 @@ def generate_demo_variables(index_date):
     # stp is an NHS administration region based on geography
   
     stp=patients.registered_practice_as_of(
-      "index_date - 1 day",
+      f"{baseline_date} - 1 day",
       returning="stp_code",
       return_expectations={
         "rate": "universal",
@@ -119,7 +119,7 @@ def generate_demo_variables(index_date):
     # NHS administrative region
   
     region=patients.registered_practice_as_of(
-      "index_date - 1 day",
+      f"{baseline_date} - 1 day",
       returning="nuts1_region_name",
       return_expectations={
         "rate": "universal",
@@ -155,7 +155,7 @@ def generate_demo_variables(index_date):
         "category": {"ratios": {"Unknown": 0.02, "1 (most deprived)": 0.18, "2": 0.2, "3": 0.2, "4": 0.2, "5 (least deprived)": 0.2}},
       },
       imd=patients.address_as_of(
-      "index_date - 1 day",
+      f"{baseline_date} - 1 day",
       returning="index_of_multiple_deprivation",
       round_to_nearest=100,
       return_expectations={
@@ -168,7 +168,7 @@ def generate_demo_variables(index_date):
     #rurality
     
     rural_urban=patients.address_as_of(
-      "index_date - 1 day",
+      f"{baseline_date} - 1 day",
       returning="rural_urban_classification",
       return_expectations={
         "rate": "universal",
@@ -189,7 +189,7 @@ def generate_demo_variables(index_date):
       "care_home='1'",
       
       care_home = patients.care_home_status_as_of(
-        "index_date - 1 day",
+        f"{baseline_date} - 1 day",
         categorised_as={
             "1": "IsPotentialCareHome",
             "": "DEFAULT",  # use empty string
@@ -200,7 +200,7 @@ def generate_demo_variables(index_date):
     # Patients in long-stay nursing and residential care
     care_home_code=patients.with_these_clinical_events(
         codelists.carehome,
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
         returning="binary_flag",
         return_expectations={"incidence": 0.01},
     ),

--- a/analysis/variables_inclusion.py
+++ b/analysis/variables_inclusion.py
@@ -5,15 +5,15 @@ import codelists
 
 specific_atrisk_date = "2020-07-01"
 
-def generate_inclusion_variables(index_date):
+def generate_inclusion_variables(baseline_date):
     inclusion_variables = dict(
     
     registered=patients.registered_as_of(
-        index_date,
+        baseline_date,
     ), 
 
     has_died=patients.died_from_any_cause(
-      on_or_before=index_date,
+      on_or_before=baseline_date,
       returning="binary_flag",
     ),
 
@@ -22,7 +22,7 @@ def generate_inclusion_variables(index_date):
     ),
     
     age = patients.age_as_of( 
-        f"{index_date} - 1 day",
+        f"{baseline_date} - 1 day",
     ),
     
     child_atrisk=patients.satisfying(
@@ -35,7 +35,7 @@ def generate_inclusion_variables(index_date):
         """,
         HHLD_IMDEF=patients.with_these_clinical_events(
             hhld_imdef_cod,
-            on_or_before="index_date - 1 day",
+            on_or_before=f"{baseline_date} - 1 day",
         ),
         nulldate=patients.fixed_value("1902-01-01"),
         ATRISK_GROUP=patients.satisfying(
@@ -73,19 +73,19 @@ def generate_inclusion_variables(index_date):
                 IMMDX=patients.with_these_clinical_events(
                     immdx_cov_cod,
                     find_last_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                 ),
                 ### any Immunosuppression medication codes is recorded
                 IMMRX=patients.with_these_clinical_events(
                     immrx_cod,
                     find_last_match_in_period=True,
-                    between=[specific_atrisk_date, "index_date - 1 day"],
+                    between=[specific_atrisk_date, f"{baseline_date} - 1 day"],
                 ),
                 ### Receiving chemotherapy or radiotherapy
                 DXT_CHEMO=patients.with_these_clinical_events(
                     dxt_chemo_cod,
                     find_last_match_in_period=True,
-                    between=["index_date - 6 months", "index_date - 1 day"],
+                    between=[f"{baseline_date} - 6 months", f"{baseline_date} - 1 day"],
                 ),
             ),
             # Patients with Chronic Kidney Disease
@@ -116,13 +116,13 @@ def generate_inclusion_variables(index_date):
                 CKD_COV=patients.with_these_clinical_events(
                     ckd_cov_cod,
                     find_first_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                 ),
                 ### Chronic kidney disease codes - all stages
                 CKD15=patients.with_these_clinical_events(
                     ckd15_cod,
                     find_last_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                 ),
                 ### date of Chronic kidney disease codes-stages 3 – 5
                 CKD35_DAT=patients.with_these_clinical_events(
@@ -130,14 +130,14 @@ def generate_inclusion_variables(index_date):
                     returning="date",
                     find_last_match_in_period=True,
                     date_format="YYYY-MM-DD",
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                 ),
                 ### date of Chronic kidney disease codes - all stages
                 CKD15_DAT=patients.with_these_clinical_events(
                     ckd15_cod,
                     returning="date",
                     date_format="YYYY-MM-DD",
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                     find_last_match_in_period=True,
                 ),
             ),
@@ -165,25 +165,25 @@ def generate_inclusion_variables(index_date):
                     ASTADM=patients.with_these_clinical_events(
                         astadm_cod,
                         find_last_match_in_period=True,
-                        between=["index_date - 730 days", "index_date - 1 day"],
+                        between=[f"{baseline_date} - 730 days", f"{baseline_date} - 1 day"],
                     ),
                     ### Asthma Diagnosis code
                     AST=patients.with_these_clinical_events(
                         ast_cod,
                         find_first_match_in_period=True,
-                        on_or_before="index_date - 1 day",
+                        on_or_before=f"{baseline_date} - 1 day",
                     ),
                     ### Asthma - inhalers in last 12 months
                     ASTRXM1=patients.with_these_medications(
                         astrxm1_cod,
                         returning="binary_flag",
-                        between=["index_date - 365 days", "index_date - 1 day"],
+                        between=[f"{baseline_date} - 365 days", f"{baseline_date} - 1 day"],
                     ),
                     ### Asthma - systemic oral steroid prescription codes in last 24 months
                     ASTRXM2=patients.with_these_medications(
                         astrxm2_cod,
                         returning="number_of_matches_in_period",
-                        between=["index_date - 730 days", "index_date - 1 day"],
+                        between=[f"{baseline_date} - 730 days", f"{baseline_date} - 1 day"],
                     ),
                 ),
                 ### Chronic Respiratory Disease
@@ -191,7 +191,7 @@ def generate_inclusion_variables(index_date):
                     resp_cov_cod,
                     find_first_match_in_period=True,
                     returning="binary_flag",
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                 ),
             ),
             ### Patients with Diabetes
@@ -214,7 +214,7 @@ def generate_inclusion_variables(index_date):
                     diab_cod,
                     returning="date",
                     find_last_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                     date_format="YYYY-MM-DD",
                 ),
                 ### Date of Diabetes resolved codes
@@ -222,7 +222,7 @@ def generate_inclusion_variables(index_date):
                     dmres_cod,
                     returning="date",
                     find_last_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                     date_format="YYYY-MM-DD",
                 ),
                 ### Addison’s disease & Pan-hypopituitary diagnosis codes
@@ -230,7 +230,7 @@ def generate_inclusion_variables(index_date):
                     addis_cod,
                     find_last_match_in_period=True,
                     returning="binary_flag",
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                 ),
                 ### Patients who are currently pregnant with gestational diabetes
                 GDIAB_GROUP=patients.satisfying(
@@ -244,7 +244,7 @@ def generate_inclusion_variables(index_date):
                         gdiab_cod,
                         find_last_match_in_period=True,
                         returning="binary_flag",
-                        between=["index_date - 254 days", "index_date - 1 day"],
+                        between=[f"{baseline_date} - 254 days", f"{baseline_date} - 1 day"],
                     ),
                     ### Patients who are currently pregnant
                     PREG1_GROUP=patients.satisfying(
@@ -259,14 +259,14 @@ def generate_inclusion_variables(index_date):
                         PREG=patients.with_these_clinical_events(
                             preg_cod,
                             returning="binary_flag",
-                            between=["index_date - 254 days", "index_date - 1 day"],
+                            between=[f"{baseline_date} - 254 days", f"{baseline_date} - 1 day"],
                         ),
                         ### Pregnancy or Delivery codes recorded in the 8.5 months before audit run date
                         PREGDEL_DAT=patients.with_these_clinical_events(
                             pregdel_cod,
                             returning="date",
                             find_last_match_in_period=True,
-                            between=["index_date - 254 days", "index_date - 1 day"],
+                            between=[f"{baseline_date} - 254 days", f"{baseline_date} - 1 day"],
                             date_format="YYYY-MM-DD",
                         ),
                         ### Date of pregnancy codes recorded in the 8.5 months before audit run date
@@ -274,7 +274,7 @@ def generate_inclusion_variables(index_date):
                             preg_cod,
                             returning="date",
                             find_last_match_in_period=True,
-                            between=["index_date - 254 days", "index_date - 1 day"],
+                            between=[f"{baseline_date} - 254 days", f"{baseline_date} - 1 day"],
                             date_format="YYYY-MM-DD",
                         ),
                     ),
@@ -285,35 +285,35 @@ def generate_inclusion_variables(index_date):
                 cld_cod,
                 find_first_match_in_period=True,
                 returning="binary_flag",
-                on_or_before="index_date - 1 day",
+                on_or_before=f"{baseline_date} - 1 day",
             ),
             ### Patients with CNS Disease (including Stroke/TIA)
             CNS_GROUP=patients.with_these_clinical_events(
                 cns_cov_cod,
                 find_first_match_in_period=True,
                 returning="binary_flag",
-                on_or_before="index_date - 1 day",
+                on_or_before=f"{baseline_date} - 1 day",
             ),
             ### Chronic heart disease codes
             CHD_COV=patients.with_these_clinical_events(
                 chd_cov_cod,
                 find_first_match_in_period=True,
                 returning="binary_flag",
-                on_or_before="index_date - 1 day",
+                on_or_before=f"{baseline_date} - 1 day",
             ),
             ### Asplenia or Dysfunction of the Spleen codes
             SPLN_COV=patients.with_these_clinical_events(
                 spln_cov_cod,
                 find_first_match_in_period=True,
                 returning="binary_flag",
-                on_or_before="index_date - 1 day",
+                on_or_before=f"{baseline_date} - 1 day",
             ),
             ### Wider Learning Disability
             LEARNDIS=patients.with_these_clinical_events(
                 learndis_cod,
                 find_last_match_in_period=True,
                 returning="binary_flag",
-                on_or_before="index_date - 1 day",
+                on_or_before=f"{baseline_date} - 1 day",
             ),
             ### Patients with Severe Mental Health
             SEVMENT_GROUP=patients.satisfying(
@@ -329,7 +329,7 @@ def generate_inclusion_variables(index_date):
                     sev_mental_cod,
                     returning="date",
                     find_last_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                     date_format="YYYY-MM-DD",
                 ),
                 ### date of Remission codes relating to Severe Mental Illness
@@ -337,7 +337,7 @@ def generate_inclusion_variables(index_date):
                     smhres_cod,
                     returning="date",
                     find_last_match_in_period=True,
-                    on_or_before="index_date - 1 day",
+                    on_or_before=f"{baseline_date} - 1 day",
                     date_format="YYYY-MM-DD",
                 ),
             ),

--- a/analysis/variables_jcvi.py
+++ b/analysis/variables_jcvi.py
@@ -3,12 +3,12 @@ from codelists import *
 import codelists
 
 
-def generate_jcvi_variables(index_date):
+def generate_jcvi_variables(baseline_date):
     jcvi_variables = dict(
     cev_ever = patients.with_these_clinical_events(
       codelists.shield,
       returning="binary_flag",
-      on_or_before = "index_date - 1 day",
+      on_or_before = f"{baseline_date} - 1 day",
       find_last_match_in_period = True,
     ),
     
@@ -21,13 +21,13 @@ def generate_jcvi_variables(index_date):
       midazolam = patients.with_these_medications(
         codelists.midazolam,
         returning="binary_flag",
-        on_or_before = "index_date - 1 day",
+        on_or_before = f"{baseline_date} - 1 day",
       ),
       
       endoflife_coding = patients.with_these_clinical_events(
         codelists.eol,
         returning="binary_flag",
-        on_or_before = "index_date - 1 day",
+        on_or_before = f"{baseline_date} - 1 day",
         find_last_match_in_period = True,
       ),
           
@@ -41,25 +41,25 @@ def generate_jcvi_variables(index_date):
           
       housebound_date=patients.with_these_clinical_events( 
         codelists.housebound, 
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
         find_last_match_in_period = True,
         returning="date",
         date_format="YYYY-MM-DD",
       ),   
       no_longer_housebound=patients.with_these_clinical_events( 
         codelists.no_longer_housebound, 
-        between=["housebound_date", "index_date - 1 day"],
+        between=["housebound_date", f"{baseline_date} - 1 day"],
       ),
       moved_into_care_home=patients.with_these_clinical_events(
         codelists.carehome,
-        between=["housebound_date", "index_date - 1 day"],
+        between=["housebound_date", f"{baseline_date} - 1 day"],
       ),
     ),
   
     prior_covid_test_frequency=patients.with_test_result_in_sgss(
       pathogen="SARS-CoV-2",
       test_result="any",
-      between=["index_date - 182 days", "index_date - 1 day"], # 182 days = 26 weeks
+      between=[f"{baseline_date} - 182 days", f"{baseline_date} - 1 day"], # 182 days = 26 weeks
       returning="number_of_matches_in_period", 
       date_format="YYYY-MM-DD",
       restrict_to_earliest_specimen_date=False,
@@ -68,11 +68,11 @@ def generate_jcvi_variables(index_date):
   # # overnight hospital admission at time of 3rd / booster dose
   # inhospital = patients.satisfying(
   
-  #   "discharged_0_date >= index_date",
+  #   "discharged_0_date >= baseline_date",
     
   #   discharged_0_date=patients.admitted_to_hospital(
   #     returning="date_discharged",
-  #     on_or_before="index_date", # this is the admission date
+  #     on_or_before=f"{baseline_date}", # this is the admission date
   #     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
   #     # see https://docs.opensafely.org/study-def-variables/#sus for more info
   #     with_admission_method = ['11', '12', '13', '21', '2A', '22', '23', '24', '25', '2D', '28', '2B', '81'],
@@ -117,17 +117,17 @@ def generate_jcvi_variables(index_date):
     ###  any immunosuppressant read code is recorded
     immdx_1=patients.with_these_clinical_events(
       codelists.immdx_cov_cod,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ### any immunosuppression medication codes is recorded
     immrx_1=patients.with_these_clinical_events(
       codelists.immrx_cod,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ### receiving chemotherapy or radiotherapy
     dxt_chemo = patients.with_these_clinical_events(
       codelists.dxt_chemo_cod ,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ),
     # patients with chronic kidney disease
@@ -144,19 +144,19 @@ def generate_jcvi_variables(index_date):
     ### chronic kidney disease diagnostic codes
     ckd_cov = patients.with_these_clinical_events(
       codelists.ckd_cov_cod,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ### chronic kidney disease codes - all stages
     ckd15 = patients.with_these_clinical_events(
       codelists.ckd15_cod,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ### date of chronic kidney disease codes-stages 3 – 5  
     ckd35_dat=patients.with_these_clinical_events(
       codelists.ckd35_cod,
     returning="date",
     date_format="YYYY-MM-DD",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     find_first_match_in_period=True,
     ),
     ### date of chronic kidney disease codes - all stages
@@ -164,7 +164,7 @@ def generate_jcvi_variables(index_date):
       codelists.ckd15_cod,
     returning="date",
     date_format="YYYY-MM-DD",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     find_first_match_in_period=True,
     ),
     ),
@@ -191,31 +191,31 @@ def generate_jcvi_variables(index_date):
         ### asthma admission codes
         astadm_1 = patients.with_these_clinical_events(
             codelists.astadm_cod,
-            on_or_before="index_date - 1 day",
+            on_or_before=f"{baseline_date} - 1 day",
         ),  
         ### asthma diagnosis code
         ast_1 = patients.with_these_clinical_events(
             codelists.ast_cod,
-            on_or_before="index_date - 1 day",
+            on_or_before=f"{baseline_date} - 1 day",
         ),  
         ### asthma - inhalers in last 12 months
         astrxm1_1=patients.with_these_medications(
             codelists.astrx_cod,
             returning="binary_flag",
-            between=["index_date - 30 days", "index_date - 1 day"],
+            between=[f"{baseline_date} - 30 days", f"{baseline_date} - 1 day"],
           ),
         ### asthma - systemic oral steroid prescription codes in last 24 months
         astrxm2_1=patients.with_these_medications(
             codelists.astrx_cod,
             returning="binary_flag",
-            between=["index_date - 60 days", "index_date - 31 days"],
+            between=[f"{baseline_date} - 60 days", f"{baseline_date} - 31 days"],
           ),
       ),
     ### chronic respiratory disease
     resp_cov_1 =patients.with_these_clinical_events(
         codelists.resp_cov_cod,
         returning="binary_flag",
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
     ),
     ),
     ### patients with diabetes
@@ -232,7 +232,7 @@ def generate_jcvi_variables(index_date):
         codelists.diab_cod,
         returning="date",
         find_last_match_in_period=True,
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
         date_format="YYYY-MM-DD",
       ),
       ### date of diabetes resolved codes
@@ -240,14 +240,14 @@ def generate_jcvi_variables(index_date):
         codelists.dmres_cod,
         returning="date",
         find_last_match_in_period=True,
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
         date_format="YYYY-MM-DD",
       ),
       ### addison’s disease & pan-hypopituitary diagnosis codes
       addis = patients.with_these_clinical_events(
         codelists.addis_cod,
         returning="binary_flag",
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
       ),
       ### patients who are currently pregnant with gestational diabetes 
       gdiab_group = patients.satisfying(
@@ -260,7 +260,7 @@ def generate_jcvi_variables(index_date):
         gdiab =  patients.with_these_clinical_events(
           codelists.gdiab_cod,
           returning="binary_flag",
-          on_or_before="index_date - 1 day",
+          on_or_before=f"{baseline_date} - 1 day",
         ),
         ### patients who are currently pregnant 
         preg1_group = patients.satisfying(
@@ -274,14 +274,14 @@ def generate_jcvi_variables(index_date):
             codelists.preg_cod,
             returning="binary_flag",
               ### pregnancy in the previous 44 weeks 
-            between=["index_date - 308 days", "index_date - 1 days"],
+            between=[f"{baseline_date} - 308 days", f"{baseline_date} - 1 days"],
             ),
             ### pregnancy or delivery codes 
             pregdel_dat=patients.with_these_clinical_events(
             codelists.pregdel_cod,
             returning="date",
             find_last_match_in_period=True,
-            on_or_before="index_date - 1 day",
+            on_or_before=f"{baseline_date} - 1 day",
             date_format="YYYY-MM-DD",
             ),
             ### date of pregnancy codes recorded
@@ -289,7 +289,7 @@ def generate_jcvi_variables(index_date):
             codelists.preg_cod,
             returning="date",
             find_last_match_in_period=True,
-            on_or_before="index_date - 1 day",
+            on_or_before=f"{baseline_date} - 1 day",
             date_format="YYYY-MM-DD",
             ),
         ),
@@ -299,31 +299,31 @@ def generate_jcvi_variables(index_date):
     cld = patients.with_these_clinical_events(
       codelists.cld_cod,
       returning="binary_flag",
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ### patients with cns disease (including stroke/tia)
     cns_group= patients.with_these_clinical_events(
       codelists.cns_cov_cod,
       returning="binary_flag",
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),  
     ### chronic heart disease codes
     chd_cov = patients.with_these_clinical_events(
       codelists.chd_cov_cod,
       returning="binary_flag",
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),  
     ### asplenia or dysfunction of the spleen codes
     spln_cov= patients.with_these_clinical_events(
         codelists.spln_cov_cod,
         returning="binary_flag",
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
     ),  
     ### wider learning disability
     learndis_1 = patients.with_these_clinical_events(
         codelists.learndis_cod,
         returning="binary_flag",
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
     ),
     ### patients with severe mental health
     sevment_group = patients.satisfying(
@@ -335,7 +335,7 @@ def generate_jcvi_variables(index_date):
         codelists.sev_mental_cod,
         returning="date",
         find_last_match_in_period=True,
-        on_or_before="index_date - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
         date_format="YYYY-MM-DD",
     ),
     ### date of remission codes relating to severe mental illness
@@ -343,7 +343,7 @@ def generate_jcvi_variables(index_date):
       codelists.smhres_cod,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
     ),
@@ -359,7 +359,7 @@ def generate_jcvi_variables(index_date):
     severely_clinically_vulnerable = patients.with_these_clinical_events(
     codelists.shield,
     returning="binary_flag",
-    on_or_before = "index_date - 1 day",
+    on_or_before = f"{baseline_date} - 1 day",
     find_last_match_in_period = True,
     ),
 
@@ -372,7 +372,7 @@ def generate_jcvi_variables(index_date):
     ### NOT SHIELDED GROUP (medium and low risk) - only flag if later than 'shielded'
     less_vulnerable = patients.with_these_clinical_events(
     codelists.nonshield,
-    between=["date_severely_clinically_vulnerable + 1 day", "index_date - 1 day",],
+    between=["date_severely_clinically_vulnerable + 1 day", f"{baseline_date} - 1 day",],
     ),
     ),
     )

--- a/analysis/variables_matching.py
+++ b/analysis/variables_matching.py
@@ -4,7 +4,7 @@ import json
 import codelists
 
 
-def generate_matching_variables(index_date):
+def generate_matching_variables(baseline_date):
   matching_variables = dict(
 
     sex=patients.sex(
@@ -35,7 +35,7 @@ def generate_matching_variables(index_date):
   #   ),
   
     practice_id=patients.registered_practice_as_of(
-      f"{index_date} - 1 day",
+      f"{baseline_date} - 1 day",
       returning="pseudo_id",
       return_expectations={
         "int": {"distribution": "normal", "mean": 1000, "stddev": 100},
@@ -46,7 +46,7 @@ def generate_matching_variables(index_date):
     # msoa
     
     msoa=patients.address_as_of(
-      f"{index_date} - 1 day",
+      f"{baseline_date} - 1 day",
       returning="msoa",
       return_expectations={
         "rate": "universal",
@@ -59,7 +59,7 @@ def generate_matching_variables(index_date):
     # stp is an NHS administration region based on geography
   
     stp=patients.registered_practice_as_of(
-      f"{index_date} - 1 day",
+      f"{baseline_date} - 1 day",
       returning="stp_code",
       return_expectations={
         "rate": "universal",
@@ -82,7 +82,7 @@ def generate_matching_variables(index_date):
     # NHS administrative region
   
     region=patients.registered_practice_as_of(
-      f"{index_date} - 1 day",
+      f"{baseline_date} - 1 day",
       returning="nuts1_region_name",
       return_expectations={
         "rate": "universal",
@@ -117,7 +117,7 @@ def generate_matching_variables(index_date):
       },
     
       imd=patients.address_as_of(
-        f"{index_date} - 1 day",
+        f"{baseline_date} - 1 day",
         returning="index_of_multiple_deprivation",
         round_to_nearest=100,
         return_expectations={
@@ -135,7 +135,7 @@ def generate_matching_variables(index_date):
       ),
       returning="date",
       date_format="YYYY-MM-DD",
-      on_or_before=f"{index_date} - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       find_last_match_in_period=True,
     ),
 
@@ -143,7 +143,7 @@ def generate_matching_variables(index_date):
     # covid_test_0_date=patients.with_test_result_in_sgss(
     #   pathogen="SARS-CoV-2",
     #   test_result="any",
-    #   on_or_before=f"{index_date} - 1 day",
+    #   on_or_before=f"{baseline_date} - 1 day",
     #   returning="date",
     #   date_format="YYYY-MM-DD",
     #   find_last_match_in_period=True,
@@ -157,7 +157,7 @@ def generate_matching_variables(index_date):
         test_result="positive",
         returning="date",
         date_format="YYYY-MM-DD",
-        on_or_before=f"{index_date} - 1 day",
+        on_or_before=f"{baseline_date} - 1 day",
         find_last_match_in_period=True,
         restrict_to_earliest_specimen_date=False,
     ),
@@ -165,7 +165,7 @@ def generate_matching_variables(index_date):
   prior_covid_test_frequency=patients.with_test_result_in_sgss(
     pathogen="SARS-CoV-2",
     test_result="any",
-    between=["index_date - 182 days", "index_date - 1 day"], # 182 days = 26 weeks
+    between=[f"{baseline_date} - 182 days", f"{baseline_date} - 1 day"], # 182 days = 26 weeks
     returning="number_of_matches_in_period", 
     date_format="YYYY-MM-DD",
     restrict_to_earliest_specimen_date=False,
@@ -175,7 +175,7 @@ def generate_matching_variables(index_date):
     # emergency attendance for covid
     covidemergency_0_date=patients.attended_emergency_care(
       returning="date_arrived",
-      on_or_before=f"{index_date} - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       with_these_diagnoses = codelists.covid_emergency,
       date_format="YYYY-MM-DD",
       find_last_match_in_period=True,
@@ -186,7 +186,7 @@ def generate_matching_variables(index_date):
       returning="date_admitted",
       with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
       with_these_diagnoses=codelists.covid_icd10,
-      on_or_before=f"{index_date} - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
       find_last_match_in_period=True,
     ),

--- a/analysis/variables_outcome.py
+++ b/analysis/variables_outcome.py
@@ -4,7 +4,7 @@ import codelists
 
 
 
-def vaccination_date_X(name, index_date, n, delay=1, product_name_matches=None, target_disease_matches=None):
+def vaccination_date_X(name, on_or_after, n, delay=1, product_name_matches=None, target_disease_matches=None):
   # vaccination date, given product_name
   def var_signature(
     name,
@@ -23,7 +23,7 @@ def vaccination_date_X(name, index_date, n, delay=1, product_name_matches=None, 
       ),
     }
     
-  variables = var_signature(f"{name}_1_date", index_date, product_name_matches, target_disease_matches)
+  variables = var_signature(f"{name}_1_date", on_or_after, product_name_matches, target_disease_matches)
   for i in range(2, n+1):
     variables.update(var_signature(
       f"{name}_{i}_date", 
@@ -34,12 +34,12 @@ def vaccination_date_X(name, index_date, n, delay=1, product_name_matches=None, 
   return variables
 
   
-def generate_outcome_variables(index_date):
+def generate_outcome_variables(baseline_date):
   outcome_variables = dict(
   
     # deregistration date
     dereg_date=patients.date_deregistered_from_all_supported_practices(
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       date_format="YYYY-MM-DD",
     ),
   
@@ -52,7 +52,7 @@ def generate_outcome_variables(index_date):
       ),
       returning="date",
       date_format="YYYY-MM-DD",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       find_first_match_in_period=True,
     ),
     
@@ -61,7 +61,7 @@ def generate_outcome_variables(index_date):
     covid_test_date=patients.with_test_result_in_sgss(
       pathogen="SARS-CoV-2",
       test_result="any",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       find_first_match_in_period=True,
       restrict_to_earliest_specimen_date=False,
       returning="date",
@@ -74,7 +74,7 @@ def generate_outcome_variables(index_date):
         test_result="positive",
         returning="date",
         date_format="YYYY-MM-DD",
-        on_or_after=index_date,
+        on_or_after=baseline_date,
         find_first_match_in_period=True,
         restrict_to_earliest_specimen_date=False,
     ),
@@ -83,7 +83,7 @@ def generate_outcome_variables(index_date):
     covidemergency_date=patients.attended_emergency_care(
       returning="date_arrived",
       date_format="YYYY-MM-DD",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       with_these_diagnoses = codelists.covid_emergency,
       find_first_match_in_period=True,
     ),
@@ -92,7 +92,7 @@ def generate_outcome_variables(index_date):
     covidemergencyhosp_date=patients.attended_emergency_care(
       returning="date_arrived",
       date_format="YYYY-MM-DD",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       find_first_match_in_period=True,
       with_these_diagnoses = codelists.covid_emergency,
       discharged_to = codelists.discharged_to_hospital,
@@ -103,7 +103,7 @@ def generate_outcome_variables(index_date):
     # respemergency_date=patients.attended_emergency_care(
     #   returning="date_arrived",
     #   date_format="YYYY-MM-DD",
-    #   on_or_after=index_date,
+    #   on_or_after=baseline_date,
     #   with_these_diagnoses = codelists.resp_emergency,
     #   find_first_match_in_period=True,
     # ),
@@ -113,7 +113,7 @@ def generate_outcome_variables(index_date):
     # respemergencyhosp_date=patients.attended_emergency_care(
     #   returning="date_arrived",
     #   date_format="YYYY-MM-DD",
-    #   on_or_after=index_date,
+    #   on_or_after=baseline_date,
     #   find_first_match_in_period=True,
     #   with_these_diagnoses = codelists.resp_emergency,
     #   discharged_to = codelists.discharged_to_hospital,
@@ -122,7 +122,7 @@ def generate_outcome_variables(index_date):
     # any emergency attendance
     emergency_date=patients.attended_emergency_care(
       returning="date_arrived",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       date_format="YYYY-MM-DD",
       find_first_match_in_period=True,
     ),
@@ -130,7 +130,7 @@ def generate_outcome_variables(index_date):
     # emergency attendance resulting in discharge to hospital
     emergencyhosp_date=patients.attended_emergency_care(
       returning="date_arrived",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       date_format="YYYY-MM-DD",
       find_last_match_in_period=True,
       discharged_to = codelists.discharged_to_hospital,
@@ -140,7 +140,7 @@ def generate_outcome_variables(index_date):
     # unplanned hospital admission
     admitted_unplanned_date=patients.admitted_to_hospital(
       returning="date_admitted",
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
       # see https://docs.opensafely.org/study-def-variables/#sus for more info
       with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
@@ -152,7 +152,7 @@ def generate_outcome_variables(index_date):
     # # planned hospital admission
     # admitted_planned_date=patients.admitted_to_hospital(
     #   returning="date_admitted",
-    #   on_or_after=index_date,
+    #   on_or_after=baseline_date,
     #   # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
     #   # see https://docs.opensafely.org/study-def-variables/#sus for more info
     #   with_admission_method=["11", "12", "13", "81"],
@@ -166,7 +166,7 @@ def generate_outcome_variables(index_date):
       returning="date_admitted",
       with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
       with_these_diagnoses=codelists.covid_icd10,
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       date_format="YYYY-MM-DD",
       find_first_match_in_period=True,
     ),
@@ -176,7 +176,7 @@ def generate_outcome_variables(index_date):
       with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
       with_these_diagnoses=codelists.covid_icd10,
       with_at_least_one_day_in_critical_care=True,
-      on_or_after=index_date,
+      on_or_after=baseline_date,
       date_format="YYYY-MM-DD",
       find_first_match_in_period=True,
     ),
@@ -195,14 +195,14 @@ def generate_outcome_variables(index_date):
     ),
     
     
-    # censor_date = patients.minimum_of("death_date", "dereg_date", f"{index_date} + 140 days"), # 140 is the maximum days of follow up, specified in design.R
-    # once the above censor_date variable is possible, then replace `f"{index_date} + 140 days"` with `censor_date` below
+    # censor_date = patients.minimum_of("death_date", "dereg_date", f"{baseline_date} + 140 days"), # 140 is the maximum days of follow up, specified in design.R
+    # once the above censor_date variable is possible, then replace `f"{baseline_date} + 140 days"` with `censor_date` below
     
     test_count = patients.with_test_result_in_sgss(
       pathogen = "SARS-CoV-2",
       test_result = "any",
       returning = "number_of_matches_in_period",
-      between = [index_date, f"{index_date} + 140 days"],
+      between = [baseline_date, f"{baseline_date} + 140 days"],
       restrict_to_earliest_specimen_date=False
     ),
 
@@ -210,7 +210,7 @@ def generate_outcome_variables(index_date):
       pathogen = "SARS-CoV-2",
       test_result = "positive",
       returning = "number_of_matches_in_period",
-      between = [index_date, f"{index_date} + 140 days"],
+      between = [baseline_date, f"{baseline_date} + 140 days"],
       restrict_to_earliest_specimen_date=False
     ),
     

--- a/analysis/variables_prebase.py
+++ b/analysis/variables_prebase.py
@@ -2,7 +2,7 @@ from cohortextractor import patients, combine_codelists
 from codelists import *
 import codelists
 
-def generate_prebase_variables(index_date):
+def generate_prebase_variables(baseline_date):
     prebase_variables = dict(
       ################################################################################################
   ## Pre-baseline events where event date is of interest
@@ -18,7 +18,7 @@ def generate_prebase_variables(index_date):
     ),
     returning="date",
     date_format="YYYY-MM-DD",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     find_last_match_in_period=True,
   ),
   
@@ -26,7 +26,7 @@ def generate_prebase_variables(index_date):
   covid_test_0_date=patients.with_test_result_in_sgss(
     pathogen="SARS-CoV-2",
     test_result="any",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     returning="date",
     date_format="YYYY-MM-DD",
     find_last_match_in_period=True,
@@ -40,7 +40,7 @@ def generate_prebase_variables(index_date):
       test_result="positive",
       returning="date",
       date_format="YYYY-MM-DD",
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       find_last_match_in_period=True,
       restrict_to_earliest_specimen_date=False,
   ),
@@ -48,7 +48,7 @@ def generate_prebase_variables(index_date):
   # emergency attendance for covid
   covidemergency_0_date=patients.attended_emergency_care(
     returning="date_arrived",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     with_these_diagnoses = codelists.covid_emergency,
     date_format="YYYY-MM-DD",
     find_last_match_in_period=True,
@@ -59,7 +59,7 @@ def generate_prebase_variables(index_date):
     returning="date_admitted",
     with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
     with_these_diagnoses=codelists.covid_icd10,
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     date_format="YYYY-MM-DD",
     find_last_match_in_period=True,
   ),  

--- a/analysis/variables_primis.py
+++ b/analysis/variables_primis.py
@@ -3,7 +3,7 @@ from codelists import *
 import json
 import codelists
 
-def generate_primis_variables(index_date,prefix):
+def generate_primis_variables(baseline_date,prefix):
     primis_variables = dict(
      # From PRIMIS
 
@@ -17,31 +17,31 @@ def generate_primis_variables(index_date,prefix):
     # # astadm=patients.with_these_clinical_events(
     # #   codelists.astadm,
     # #   returning="binary_flag",
-    # #   on_or_before="index_date - 1 day",
+    # #   on_or_before=f"{baseline_date} - 1 day",
     # # ),
     # # # Asthma Diagnosis code
     # # ast = patients.with_these_clinical_events(
     # #   codelists.ast,
     # #   returning="binary_flag",
-    # #   on_or_before="index_date - 1 day",
+    # #   on_or_before=f"{baseline_date} - 1 day",
     # # ),
     # # # Asthma systemic steroid prescription code in month 1
     # # astrxm1=patients.with_these_medications(
     # #   codelists.astrx,
     # #   returning="binary_flag",
-    # #   between=["index_date - 30 days", "index_date - 1 day"],
+    # #   between=[f"{baseline_date} - 30 days", f"{baseline_date} - 1 day"],
     # # ),
     # # # Asthma systemic steroid prescription code in month 2
     # # astrxm2=patients.with_these_medications(
     # #   codelists.astrx,
     # #   returning="binary_flag",
-    # #   between=["index_date - 60 days", "index_date - 31 days"],
+    # #   between=[f"{baseline_date} - 60 days", f"{baseline_date} - 31 days"],
     # # ),
     # # Asthma systemic steroid prescription code in month 3
     # astrxm3=patients.with_these_medications(
     #   codelists.astrx,
     #   returning="binary_flag",
-    #   between= ["index_date - 90 days", "index_date - 61 days"],
+    #   between= [f"{baseline_date} - 90 days", f"{baseline_date} - 61 days"],
     # ),
 
     # ),
@@ -50,7 +50,7 @@ def generate_primis_variables(index_date,prefix):
     chronic_neuro_disease=patients.with_these_clinical_events(
     codelists.cns_cov,
     returning="binary_flag",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     ),
 
     # # Chronic Respiratory Disease
@@ -59,7 +59,7 @@ def generate_primis_variables(index_date,prefix):
     # resp_cov=patients.with_these_clinical_events(
     #   codelists.resp_cov,
     #   returning="binary_flag",
-    #   on_or_before="index_date - 1 day",
+    #   on_or_before=f"{baseline_date} - 1 day",
     # ),
     # ),
 
@@ -73,7 +73,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.bmi_stage,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
 
@@ -82,7 +82,7 @@ def generate_primis_variables(index_date,prefix):
       returning="date",
       find_last_match_in_period=True,
       ignore_missing_values=True,
-      between= ["bmi_stage_date", "index_date - 1 day"],
+      between= ["bmi_stage_date", f"{baseline_date} - 1 day"],
       date_format="YYYY-MM-DD",
     ),
 
@@ -91,7 +91,7 @@ def generate_primis_variables(index_date,prefix):
       returning="date",
       ignore_missing_values=True,
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
 
@@ -100,7 +100,7 @@ def generate_primis_variables(index_date,prefix):
       returning="numeric_value",
       ignore_missing_values=True,
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
 
     ),
@@ -112,7 +112,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.diab,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
 
@@ -120,7 +120,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.dmres,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
     ),
@@ -133,7 +133,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.sev_mental,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
     # Remission codes relating to Severe Mental Illness
@@ -141,7 +141,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.smhres,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
     ),
@@ -151,7 +151,7 @@ def generate_primis_variables(index_date,prefix):
     chronic_heart_disease=patients.with_these_clinical_events(
       codelists.chd_cov,
       returning="binary_flag",
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
 
     chronic_kidney_disease=patients.satisfying(
@@ -165,7 +165,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.ckd15,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
 
@@ -174,7 +174,7 @@ def generate_primis_variables(index_date,prefix):
       codelists.ckd35,
       returning="date",
       find_last_match_in_period=True,
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
       date_format="YYYY-MM-DD",
     ),
 
@@ -182,7 +182,7 @@ def generate_primis_variables(index_date,prefix):
     ckd=patients.with_these_clinical_events(
       codelists.ckd_cov,
       returning="binary_flag",
-      on_or_before="index_date - 1 day",
+      on_or_before=f"{baseline_date} - 1 day",
     ),
     ),
 
@@ -191,7 +191,7 @@ def generate_primis_variables(index_date,prefix):
     chronic_liver_disease=patients.with_these_clinical_events(
     codelists.cld,
     returning="binary_flag",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     ),
 
 
@@ -202,13 +202,13 @@ def generate_primis_variables(index_date,prefix):
     # immdx=patients.with_these_clinical_events(
     #   codelists.immdx_cov,
     #   returning="binary_flag",
-    #   on_or_before="index_date - 1 day",
+    #   on_or_before=f"{baseline_date} - 1 day",
     # ),
     # # Immunosuppression medication codes
     # immrx=patients.with_these_medications(
     #   codelists.immrx,
     #   returning="binary_flag",
-    #   between=["index_date - 182 days", "index_date - 1 day"]
+    #   between=[f"{baseline_date} - 182 days", f"{baseline_date} - 1 day"]
     # ),
     # ),
 
@@ -216,14 +216,14 @@ def generate_primis_variables(index_date,prefix):
     asplenia=patients.with_these_clinical_events(
     codelists.spln_cov,
     returning="binary_flag",
-    on_or_before="index_date - 1 day",
+    on_or_before=f"{baseline_date} - 1 day",
     ),
 
     # Wider Learning Disability
     # learndis=patients.with_these_clinical_events(
     # codelists.learndis,
     # returning="binary_flag",
-    # on_or_before="index_date - 1 day",
+    # on_or_before=f"{baseline_date} - 1 day",
     # ),
 
 
@@ -232,7 +232,7 @@ def generate_primis_variables(index_date,prefix):
     #   codelists.hhld_imdef,
     #   returning="date",
     #   find_last_match_in_period=True,
-    #   on_or_before="index_date - 1 day",
+    #   on_or_before=f"{baseline_date} - 1 day",
     #   date_format="YYYY-MM-DD",
     # ),
     #
@@ -247,7 +247,7 @@ def generate_primis_variables(index_date,prefix):
     #     codelists.cancer_haem_icd10,
     #     codelists.cancer_unspec_icd10,
     #   ),
-    #   between=["index_date - 3 years", "index_date - 1 day"],
+    #   between=[f"{baseline_date} - 3 years", f"{baseline_date} - 1 day"],
     #   returning="binary_flag",
     # ),
     cancer_primary_care=patients.with_these_clinical_events( 
@@ -255,7 +255,7 @@ def generate_primis_variables(index_date,prefix):
         codelists.cancer_nonhaem_snomed,
         codelists.cancer_haem_snomed
       ),
-      between=["index_date - 3 years", "index_date - 1 day"],
+      between=[f"{baseline_date} - 3 years", f"{baseline_date} - 1 day"],
       returning="binary_flag",
     ), 
     ),


### PR DESCRIPTION
* Use "baseline_date" instead of "index_date" to avoid confusion between the specific study definition meaning and more generic meanings
* fix references to baseline (formerly index) dates, using f-strings where appropriate
* drive-by updates to comments