### PR TITLE
shorten censoring time by one day

### DIFF
--- a/analysis/covidtests/process_covidtests.R
+++ b/analysis/covidtests/process_covidtests.R
@@ -235,7 +235,7 @@ data_split <- local({
       ),
       tte_censor = as.integer(censor_date-(trial_date-1)),
       ind_outcome = 0
-      # censor_date = trial_date + maxfup # use this to overwrite above definition until issue with `patients.minimum_of()` and date arithmetic is fixed
+      # censor_date = trial_date + maxfup -1 # use this to overwrite above definition until issue with `patients.minimum_of()` and date arithmetic is fixed
     ) %>%
     select(patient_id, trial_date, treated, censor_date, tte_censor) %>%
     group_by(patient_id, trial_date) %>%

--- a/analysis/model/eventcounts.R
+++ b/analysis/model/eventcounts.R
@@ -81,10 +81,10 @@ data_matched <-
       # vax2_date-1, # -1 because we assume vax occurs at the start of the day
       death_date,
       dates[[c(glue("followupend_date{vaxn}"))]],
-      trial_date + maxfup,
+      trial_date + maxfup - 1,
       na.rm = TRUE
     ),
-    censor_date = trial_date + maxfup # use this to overwrite above definition until issue with `patients.minimum_of()` and date arithmetic is fixed
+    censor_date = trial_date + maxfup - 1 # use this to overwrite above definition until issue with `patients.minimum_of()` and date arithmetic is fixed
   )
 
 # report number of tests ----

--- a/analysis/model/km.R
+++ b/analysis/model/km.R
@@ -92,7 +92,7 @@ data_matched <-
       # vax2_date-1, # -1 because we assume vax occurs at the start of the day
       death_date,
       dates[[c(glue("followupend_date{vaxn}"))]],
-      trial_date + maxfup,
+      trial_date + maxfup - 1,
       na.rm = TRUE
     ),
     matchcensor_date = pmin(censor_date, controlistreated_date - 1, na.rm = TRUE), # new censor date based on whether control gets treated or not


### PR DESCRIPTION
This ensures that trial date / vax date is interpreted as the _start of_ the day, not the end of the day as for all other event times. This is because if vaccination and an event occur on the same day, we assume that vaccination happens first.